### PR TITLE
BFD Offload Support

### DIFF
--- a/inc/saibfd.h
+++ b/inc/saibfd.h
@@ -53,6 +53,22 @@ typedef enum _sai_bfd_session_type_t
 } sai_bfd_session_type_t;
 
 /**
+ * @brief SAI offload type of BFD session
+ */
+typedef enum _sai_bfd_session_offload_type_t
+{
+    /** Full Offload: both session establishment and sustenance */
+    SAI_BFD_SESSION_OFFLOAD_TYPE_FULL = 0,
+
+    /** Sustenance Offload: Session Sustenance only. */
+    SAI_BFD_SESSION_OFFLOAD_TYPE_SUSTENANCE,
+
+    /** No Offload: No offload supported */
+    SAI_BFD_SESSION_OFFLOAD_TYPE_NONE,
+
+} sai_bfd_session_offload_type_t;
+
+/**
  * @brief SAI type of encapsulation for BFD
  */
 typedef enum _sai_bfd_encapsulation_type_t
@@ -411,6 +427,14 @@ typedef enum _sai_bfd_session_attr_t
      * @flags READ_ONLY
      */
     SAI_BFD_SESSION_ATTR_STATE,
+
+    /**
+     * @brief Offload type
+     *
+     * @type sai_bfd_session_offload_type_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_BFD_SESSION_ATTR_BFD_SESSION_OFFLOAD_TYPE,
 
     /**
      * @brief End of attributes

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1635,6 +1635,14 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_MAX_BFD_SESSION,
 
     /**
+     * @brief List of BFD session offloads that are supported
+     *
+     * @type sai_s32_list_t sai_bfd_session_offload_type_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_SUPPORTED_BFD_SESSION_OFFLOAD_TYPE,
+
+    /**
      * @brief Minimum Receive interval NPU supports in microseconds
      *
      * @type sai_uint32_t


### PR DESCRIPTION
There are hardware offloads available for establishing and sustaining BFD sessions. This pull request aims to add capabilities for the SAI/BFD API to allow applications to query the list of supported offloads and choose an offload while creating a BFD session.

*) Session Offload Type is a new attribute for the BFD session object. 
 - The offload type  'SAI_BFD_SESSION_OFFLOAD_TYPE_FULL' offload indicates that underlying silicon is capable of establishing and sustaining BFD sessions with given parameters. 
- The offload type  'SAI_BFD_SESSION_OFFLOAD_TYPE_SUSTENANCE' offload indicates that underlying silicon is capable of sustaining an control-plane established BFD session 
- The offload type 'SAI_BFD_SESSION_OFFLOAD_TYPE_NONE' indicates that there is no offload available.

BFD API already has mechanisms to report session establishment and tear-down via notifications. 

*) The switch object has a new RO attribute to obtain a list of supported BFD offload types.