### PR TITLE
Add attr to port-obj for timestamping for PTP Pkts

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -186,6 +186,19 @@ typedef enum _sai_port_priority_flow_control_mode_t
 } sai_port_priority_flow_control_mode_t;
 
 /**
+ * @brief PTP mode
+ */
+typedef enum _sai_port_ptp_mode_t
+{
+    /** No special processing for PTP packets */
+    SAI_PORT_PTP_MODE_NONE,
+
+    /** Timestamp the PTP packets */
+    SAI_PORT_PTP_MODE_TIMESTAMP,
+
+} sai_port_ptp_mode_t;
+
+/**
  * @brief Attribute Id in sai_set_port_attribute() and
  * sai_get_port_attribute() calls
  */
@@ -1189,6 +1202,15 @@ typedef enum _sai_port_attr_t
      * @default false
      */
     SAI_PORT_ATTR_LINK_TRAINING_ENABLE,
+
+    /**
+     * @brief Configure PTP mode on the port
+     *
+     * @type sai_port_ptp_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PORT_PTP_MODE_NONE
+     */
+    SAI_PORT_ATTR_PTP_MODE,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
Add an optional attribute to port-object to support timestamping for PTP Packets.